### PR TITLE
Update ScrollReveal library version and Twitter image URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
     <meta property="twitter:url" content="https://jpxoi.com">
     <meta name="twitter:title" content="Jean Paul Fernandez — Software Engineer">
     <meta name="twitter:description" content="Software Engineer, Frontend Developer, and UI/UX Designer. Join me on a cutting-edge journey, where my ambitious spirit and self-taught expertise converge to craft visually stunning, tech-innovative projects.">
-    <meta name="twitter:image" content="https://jpxoi.com/img/social-card.webp">
+    <meta name="twitter:image" content="https://static.jpxoi.com/media/uploads/social-card.webp">
     <meta name="twitter:image:alt" content="Preview of Jean Paul Fernandez's website">
     <meta name="twitter:site" content="@jpxoi">
     <meta name="twitter:creator" content="@jpxoi">

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     <div id="root"></div>
 
     <!--=============== SCROLLREVEAL ===============-->
-    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="https://unpkg.com/scrollreveal@4.0.9/dist/scrollreveal.min.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,6 @@
     <div id="root"></div>
 
     <!--=============== SCROLLREVEAL ===============-->
-    <script src="https://unpkg.com/scrollreveal@4.0.9/dist/scrollreveal.min.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
This pull request updates the ScrollReveal library version and the Twitter image URL in the index.html file. The ScrollReveal script tag is removed and the Twitter image URL is changed from "https://jpxoi.com/img/social-card.webp" to "https://static.jpxoi.com/media/uploads/social-card.webp".